### PR TITLE
Use relative links when not using markdown

### DIFF
--- a/docs/staff.md
+++ b/docs/staff.md
@@ -7,7 +7,7 @@ tr { vertical-align: baseline; }
 <table>
   <tbody>
     <tr>
-      <td><img alt="Tim C. photo" src="../files/staff/tim-cartwright.png" height="128" width="128"></td>
+      <td width="150px"><img alt="Tim C. photo" src="../files/staff/tim-cartwright.png" height="128" width="128"></td>
       <td>
         <p style="font-weight: bold;">Tim Cartwright</p>
         <p>
@@ -19,7 +19,7 @@ tr { vertical-align: baseline; }
       </td>
     </tr>
     <tr>
-      <td><img alt="Lauren M. photo" src="../files/staff/lauren-michael.png" height="128" width="128"></td>
+      <td width="150px"><img alt="Lauren M. photo" src="../files/staff/lauren-michael.png" height="128" width="128"></td>
       <td>
         <p style="font-weight: bold;">Lauren Michael</p>
         <p>

--- a/docs/staff.md
+++ b/docs/staff.md
@@ -7,7 +7,7 @@ tr { vertical-align: baseline; }
 <table>
   <tbody>
     <tr>
-      <td><img alt="Tim C. photo" src="/files/staff/tim-cartwright.png" height="128" width="128"></td>
+      <td><img alt="Tim C. photo" src="../files/staff/tim-cartwright.png" height="128" width="128"></td>
       <td>
         <p style="font-weight: bold;">Tim Cartwright</p>
         <p>
@@ -19,7 +19,7 @@ tr { vertical-align: baseline; }
       </td>
     </tr>
     <tr>
-      <td><img alt="Lauren M. photo" src="/files/staff/lauren-michael.png" height="128" width="128"></td>
+      <td><img alt="Lauren M. photo" src="../files/staff/lauren-michael.png" height="128" width="128"></td>
       <td>
         <p style="font-weight: bold;">Lauren Michael</p>
         <p>


### PR DESCRIPTION
MkDocs generates relative links, e.g.:

```
<p><img alt="BLAST landing page" src="../../../materials/sw/files/part1-ex1-blast-landing-page.png" /></p>
```

Unfortunately there's some styling somewhere that appears to be screwing with the aspect ratios:

![narrow-images](https://user-images.githubusercontent.com/390105/87311169-828ba980-c4e4-11ea-8307-8e1d8632aa01.png)
