### PR TITLE
Rename the OSG section to dHTC

### DIFF
--- a/docs/materials/index.md
+++ b/docs/materials/index.md
@@ -27,7 +27,7 @@ Lecture recording will be linked here.
 - [Bonus Exercise 3.2: Explore `condor_status`](/materials/htc/part3-ex2-status.md)
 - [Bonus Exercise 3.3: A job that needs retries](/materials/htc/part3-ex3-job-retry.md)
 
-## Distributed High-Throughput Computing (dHTC)
+## Grid
 
 - [Exercise 1: Refresher – Submitting Multiple Jobs](/materials/osg/ex1-submit-refresher.md)
 - [Exercise 2: Log in to the OSG Submit Server](/materials/osg/ex2-login-scp.md)

--- a/docs/materials/index.md
+++ b/docs/materials/index.md
@@ -29,6 +29,8 @@ Lecture recording will be linked here.
 
 ## Grid
 
+All exercises strongly recommended!
+
 - [Exercise 1: Refresher – Submitting Multiple Jobs](/materials/osg/ex1-submit-refresher.md)
 - [Exercise 2: Log in to the OSG Submit Server](/materials/osg/ex2-login-scp.md)
 - [Exercise 3: Running jobs in the OSG](/materials/osg/ex3-submit-osg.md)

--- a/docs/materials/index.md
+++ b/docs/materials/index.md
@@ -27,7 +27,7 @@ Lecture recording will be linked here.
 - [Bonus Exercise 3.2: Explore `condor_status`](/materials/htc/part3-ex2-status.md)
 - [Bonus Exercise 3.3: A job that needs retries](/materials/htc/part3-ex3-job-retry.md)
 
-## OSG
+## Distributed High-Throughput Computing (dHTC)
 
 - [Exercise 1: Refresher – Submitting Multiple Jobs](/materials/osg/ex1-submit-refresher.md)
 - [Exercise 2: Log in to the OSG Submit Server](/materials/osg/ex2-login-scp.md)

--- a/docs/materials/osg/ex1-submit-refresher.md
+++ b/docs/materials/osg/ex1-submit-refresher.md
@@ -2,8 +2,8 @@
 status: testing
 ---
 
-OSG Exercise 1: Refresher – Submitting Multiple Jobs
-====================================================
+dHTC Exercise 1: Refresher – Submitting Multiple Jobs
+=====================================================
 
 The goal of this exercise is to map the physical locations of some worker servers in our local cluster.
 To do this, you will write a simple submit file that will queue multiple jobs and then manually collate the results.
@@ -19,7 +19,7 @@ Geolocation uses a registry to match a computer’s network address to an approx
 Now, let’s try to remember some basic HTCondor ideas from earlier today:
 
 1.  Log in to `learn.chtc.wisc.edu`
-1.  Create and change into a new folder for this exercise, for example `osg-ex1`
+1.  Create and change into a new folder for this exercise, for example `dhtc-ex1`
 1.  Download the geolocation code:
 
         :::console

--- a/docs/materials/osg/ex1-submit-refresher.md
+++ b/docs/materials/osg/ex1-submit-refresher.md
@@ -2,7 +2,7 @@
 status: testing
 ---
 
-dHTC Exercise 1: Refresher – Submitting Multiple Jobs
+Grid Exercise 1: Refresher – Submitting Multiple Jobs
 =====================================================
 
 The goal of this exercise is to map the physical locations of some worker servers in our local cluster.
@@ -19,7 +19,7 @@ Geolocation uses a registry to match a computer’s network address to an approx
 Now, let’s try to remember some basic HTCondor ideas from earlier today:
 
 1.  Log in to `learn.chtc.wisc.edu`
-1.  Create and change into a new folder for this exercise, for example `dhtc-ex1`
+1.  Create and change into a new folder for this exercise, for example `grid-ex1`
 1.  Download the geolocation code:
 
         :::console

--- a/docs/materials/osg/ex2-login-scp.md
+++ b/docs/materials/osg/ex2-login-scp.md
@@ -2,8 +2,8 @@
 status: testing
 ---
 
-OSG Exercise 2: Log in to the OSG Submit Server
-===============================================
+dHTC Exercise 2: Log in to the OSG Submit Server
+================================================
 
 The goal of this exercise is to log in to a different submit host so that you can start submitting jobs into the OSG
 instead of the local cluster here at UW-Madison.
@@ -52,7 +52,7 @@ tarballs) whose usage is as follows:
         :::console
         user@learn $ tar -tzvf <archive filename>
 
-Using the above knowledge, log into `learn.chtc.wisc.edu`, create a tarball that contains the OSG exercise 1 directory,
+Using the above knowledge, log into `learn.chtc.wisc.edu`, create a tarball that contains the dHTC exercise 1 directory,
 and verify that it contains all the proper files.
 
 ### Comparing compressed sizes
@@ -62,7 +62,7 @@ You can adjust the level of compression of `tar` by prepending your command with
 compression is between `best` and `fast`).
 
 1.  Log in to `learn.chtc.wisc.edu`
-1.  Create and change into a new folder for this exercise, for example `osg-ex2`
+1.  Create and change into a new folder for this exercise, for example `dhtc-ex2`
 1.  Use `wget` to download the following files from our web server:
     1.  Text file: <http://proxy.chtc.wisc.edu/SQUID/osgschool19/random_text>
     1.  Archive: <http://proxy.chtc.wisc.edu/SQUID/osgschool19/pdbaa.tar.gz>
@@ -120,7 +120,7 @@ server's operating system:
 #### Mac and Linux users
 
 `scp` should be included by default and available via the terminal on both Mac and Linux operating systems.
-Open a terminal window on your laptop and try copying the tarball containing the OSG exercise 1 from
+Open a terminal window on your laptop and try copying the tarball containing the dHTC exercise 1 from
 `login04.osgconnect.net` to your laptop.
 
 #### Windows users
@@ -129,7 +129,7 @@ WinSCP is an `scp` client for Windows operating systems.
 
 1.  Install WinSCP from <https://winscp.net/eng/index.php>
 1.  Start WinSCP and enter your SSH credentials for `login04.osgconnect.net`
-1.  Copy the tarball containing OSG exercise 1 to your laptop
+1.  Copy the tarball containing dHTC exercise 1 to your laptop
 
 ### Extra challenge: Using rsync
 
@@ -150,9 +150,9 @@ Both of these feature are helpful when you're having connectivity issues so that
 from scratch every time your connection fails.
 
 1.  Log in to `login04.osgconnect.net`
-1.  Use `rsync` to transfer the folder containing OSG exercise 1 on `learn.chtc.wisc.edu` to `login04.osgconnect.net`
+1.  Use `rsync` to transfer the folder containing dHTC exercise 1 on `learn.chtc.wisc.edu` to `login04.osgconnect.net`
 1.  In a separate terminal window, log in to `learn.chtc.wisc.edu`
-1.  Create a new file in your OSG exercise 1 folder on `learn.chtc.wisc.edu` with the `touch` command:
+1.  Create a new file in your dHTC exercise 1 folder on `learn.chtc.wisc.edu` with the `touch` command:
 
         :::console
         user@learn $ touch <filename>

--- a/docs/materials/osg/ex2-login-scp.md
+++ b/docs/materials/osg/ex2-login-scp.md
@@ -52,7 +52,7 @@ tarballs) whose usage is as follows:
         :::console
         user@learn $ tar -tzvf <archive filename>
 
-Using the above knowledge, log into `learn.chtc.wisc.edu`, create a tarball that contains the dHTC exercise 1 directory,
+Using the above knowledge, log into `learn.chtc.wisc.edu`, create a tarball that contains the Grid exercise 1 directory,
 and verify that it contains all the proper files.
 
 ### Comparing compressed sizes
@@ -120,7 +120,7 @@ server's operating system:
 #### Mac and Linux users
 
 `scp` should be included by default and available via the terminal on both Mac and Linux operating systems.
-Open a terminal window on your laptop and try copying the tarball containing the dHTC exercise 1 from
+Open a terminal window on your laptop and try copying the tarball containing the Grid exercise 1 from
 `login04.osgconnect.net` to your laptop.
 
 #### Windows users
@@ -129,7 +129,7 @@ WinSCP is an `scp` client for Windows operating systems.
 
 1.  Install WinSCP from <https://winscp.net/eng/index.php>
 1.  Start WinSCP and enter your SSH credentials for `login04.osgconnect.net`
-1.  Copy the tarball containing dHTC exercise 1 to your laptop
+1.  Copy the tarball containing Grid exercise 1 to your laptop
 
 ### Extra challenge: Using rsync
 
@@ -150,9 +150,9 @@ Both of these feature are helpful when you're having connectivity issues so that
 from scratch every time your connection fails.
 
 1.  Log in to `login04.osgconnect.net`
-1.  Use `rsync` to transfer the folder containing dHTC exercise 1 on `learn.chtc.wisc.edu` to `login04.osgconnect.net`
+1.  Use `rsync` to transfer the folder containing Grid exercise 1 on `learn.chtc.wisc.edu` to `login04.osgconnect.net`
 1.  In a separate terminal window, log in to `learn.chtc.wisc.edu`
-1.  Create a new file in your dHTC exercise 1 folder on `learn.chtc.wisc.edu` with the `touch` command:
+1.  Create a new file in your Grid exercise 1 folder on `learn.chtc.wisc.edu` with the `touch` command:
 
         :::console
         user@learn $ touch <filename>

--- a/docs/materials/osg/ex2-login-scp.md
+++ b/docs/materials/osg/ex2-login-scp.md
@@ -2,7 +2,7 @@
 status: testing
 ---
 
-dHTC Exercise 2: Log in to the OSG Submit Server
+Grid Exercise 2: Log in to the OSG Submit Server
 ================================================
 
 The goal of this exercise is to log in to a different submit host so that you can start submitting jobs into the OSG
@@ -62,7 +62,7 @@ You can adjust the level of compression of `tar` by prepending your command with
 compression is between `best` and `fast`).
 
 1.  Log in to `learn.chtc.wisc.edu`
-1.  Create and change into a new folder for this exercise, for example `dhtc-ex2`
+1.  Create and change into a new folder for this exercise, for example `grid-ex2`
 1.  Use `wget` to download the following files from our web server:
     1.  Text file: <http://proxy.chtc.wisc.edu/SQUID/osgschool19/random_text>
     1.  Archive: <http://proxy.chtc.wisc.edu/SQUID/osgschool19/pdbaa.tar.gz>

--- a/docs/materials/osg/ex3-submit-osg.md
+++ b/docs/materials/osg/ex3-submit-osg.md
@@ -12,7 +12,7 @@ Where in the world are my jobs? (Part 2)
 
 In this version of the geolocating exercise, you will submit jobs to the OSG from `login04.osgconnect.net` and
 hopefully getting back much more interesting results!
-You will be using the same exact payload as you did in [dHTC exercise 1](/materials/osg/ex1-submit-refresher).
+You will be using the same exact payload as you did in [Grid exercise 1](/materials/osg/ex1-submit-refresher).
 
 ### Gathering network information from the OSG
 
@@ -20,9 +20,9 @@ Now to create submit files that will run in the OSG!
 
 1. If not already logged in, `ssh` into `login04.osgconnect.net`
 1. Make a new directory for this exercise, `grid-ex3` and change into it
-1. Use `scp` or `rsync` from [dHTC exercise 2](/materials/osg/ex2-login-scp) to copy over the executable and input
+1. Use `scp` or `rsync` from [Grid exercise 2](/materials/osg/ex2-login-scp) to copy over the executable and input
    file from the `grid-ex1` directory from `learn`.
-1. Re-create the submit file from dHTC exercise 1 except this time around change your submit file so that it submits
+1. Re-create the submit file from Grid exercise 1 except this time around change your submit file so that it submits
    **five hundred** jobs!
 1. Submit your file and wait for the results
 

--- a/docs/materials/osg/ex3-submit-osg.md
+++ b/docs/materials/osg/ex3-submit-osg.md
@@ -2,8 +2,8 @@
 status: testing
 ---
 
-OSG Exercise 3: Running jobs in the OSG
-=======================================
+dHTC Exercise 3: Running jobs in the OSG
+========================================
 
 The goal of this exercise is to have your jobs running on the OSG and map their geographical locations.
 
@@ -12,17 +12,17 @@ Where in the world are my jobs? (Part 2)
 
 In this version of the geolocating exercise, you will submit jobs to the OSG from `login04.osgconnect.net` and
 hopefully getting back much more interesting results!
-You will be using the same exact payload as you did in [OSG exercise 1](/materials/osg/ex1-submit-refresher).
+You will be using the same exact payload as you did in [dHTC exercise 1](/materials/osg/ex1-submit-refresher).
 
 ### Gathering network information from the OSG
 
 Now to create submit files that will run in the OSG!
 
 1. If not already logged in, `ssh` into `login04.osgconnect.net`
-1. Make a new directory for this exercise, `osg-ex3` and change into it
-1. Use `scp` or `rsync` from [OSG exercise 2](/materials/osg/ex2-login-scp) to copy over the executable and input
-   file from the `osg-ex1` directory from `learn`.
-1. Re-create the submit file from OSG exercise 1 except this time around change your submit file so that it submits
+1. Make a new directory for this exercise, `dhtc-ex3` and change into it
+1. Use `scp` or `rsync` from [dHTC exercise 2](/materials/osg/ex2-login-scp) to copy over the executable and input
+   file from the `dhtc-ex1` directory from `learn`.
+1. Re-create the submit file from dHTC exercise 1 except this time around change your submit file so that it submits
    **five hundred** jobs!
 1. Submit your file and wait for the results
 

--- a/docs/materials/osg/ex3-submit-osg.md
+++ b/docs/materials/osg/ex3-submit-osg.md
@@ -2,7 +2,7 @@
 status: testing
 ---
 
-dHTC Exercise 3: Running jobs in the OSG
+Grid Exercise 3: Running jobs in the OSG
 ========================================
 
 The goal of this exercise is to have your jobs running on the OSG and map their geographical locations.
@@ -19,9 +19,9 @@ You will be using the same exact payload as you did in [dHTC exercise 1](/materi
 Now to create submit files that will run in the OSG!
 
 1. If not already logged in, `ssh` into `login04.osgconnect.net`
-1. Make a new directory for this exercise, `dhtc-ex3` and change into it
+1. Make a new directory for this exercise, `grid-ex3` and change into it
 1. Use `scp` or `rsync` from [dHTC exercise 2](/materials/osg/ex2-login-scp) to copy over the executable and input
-   file from the `dhtc-ex1` directory from `learn`.
+   file from the `grid-ex1` directory from `learn`.
 1. Re-create the submit file from dHTC exercise 1 except this time around change your submit file so that it submits
    **five hundred** jobs!
 1. Submit your file and wait for the results

--- a/docs/materials/osg/ex4-hardware-diffs.md
+++ b/docs/materials/osg/ex4-hardware-diffs.md
@@ -101,7 +101,7 @@ Checking OSG memory availability
 
 For the second part of the exercise, you will just copy over the directory from the [above section](#checking-chtc-memory-availability)
 on `learn.chtc.wisc.edu` to `login04.osgconnect.net` and resubmit your jobs to the OSG.
-If you get stuck during the copying process, refer to [OSG exercise 2](/materials/osg/ex2-login-scp.md).
+If you get stuck during the copying process, refer to [Grid exercise 2](/materials/osg/ex2-login-scp.md).
 
 ### Monitoring the remote jobs
 

--- a/docs/materials/osg/ex4-hardware-diffs.md
+++ b/docs/materials/osg/ex4-hardware-diffs.md
@@ -2,7 +2,7 @@
 status: testing
 ---
 
-dHTC Exercise 4: Hardware Differences in the OSG
+Grid Exercise 4: Hardware Differences in the OSG
 ================================================
 
 The goal of this exercise is to compare hardware differences between our local cluster (CHTC here at UW–Madison) and an
@@ -60,7 +60,7 @@ To create our parameter sweep, we will create a **new** submit file with multipl
 of our parameter (`request_memory`) for each batch of jobs.
 
 1.  If not already, log in to `learn.chtc.wisc.edu`
-1.  Create and change into a new subdirectory called `dhtc-ex4`
+1.  Create and change into a new subdirectory called `grid-ex4`
 1.  Create a submit file that is named `sleep.sub` that executes the command `/bin/sleep 300`.
 
     !!! note

--- a/docs/materials/osg/ex4-hardware-diffs.md
+++ b/docs/materials/osg/ex4-hardware-diffs.md
@@ -2,8 +2,8 @@
 status: testing
 ---
 
-OSG Exercise 4: Hardware Differences in the OSG
-===============================================
+dHTC Exercise 4: Hardware Differences in the OSG
+================================================
 
 The goal of this exercise is to compare hardware differences between our local cluster (CHTC here at UW–Madison) and an
 OSG glidein pool.
@@ -60,7 +60,7 @@ To create our parameter sweep, we will create a **new** submit file with multipl
 of our parameter (`request_memory`) for each batch of jobs.
 
 1.  If not already, log in to `learn.chtc.wisc.edu`
-1.  Create and change into a new subdirectory called `osg-ex4`
+1.  Create and change into a new subdirectory called `dhtc-ex4`
 1.  Create a submit file that is named `sleep.sub` that executes the command `/bin/sleep 300`.
 
     !!! note

--- a/docs/materials/osg/ex4-hardware-diffs.md
+++ b/docs/materials/osg/ex4-hardware-diffs.md
@@ -101,7 +101,7 @@ Checking OSG memory availability
 
 For the second part of the exercise, you will just copy over the directory from the [above section](#checking-chtc-memory-availability)
 on `learn.chtc.wisc.edu` to `login04.osgconnect.net` and resubmit your jobs to the OSG.
-If you get stuck during the copying process, refer to [OSG exercise 4](/materials/osg/ex2-login-scp.md).
+If you get stuck during the copying process, refer to [OSG exercise 2](/materials/osg/ex2-login-scp.md).
 
 ### Monitoring the remote jobs
 

--- a/docs/materials/osg/ex5-software-diffs.md
+++ b/docs/materials/osg/ex5-software-diffs.md
@@ -2,8 +2,8 @@
 status: testing
 ---
 
-OSG Exercise 5: Software Differences in the OSG
-===============================================
+dHTC Exercise 5: Software Differences in the OSG
+================================================
 
 The goal of this exercise is to see the differences in availability of software in the OSG.
 At your local cluster, you may be used to having certain versions of software but out on the OSG, it's possible that the
@@ -110,7 +110,7 @@ get_version 'nslookup'
 For this part of the exercise, try creating a submit file without referring to previous exercises!
 
 1.  Log in to `login04.osgconnect.net`
-1.  Create and change into a new folder for this exercise, e.g. `osg-ex5`
+1.  Create and change into a new folder for this exercise, e.g. `dhtc-ex5`
 1.  Save the above script as a file named `sw_probe.sh`
 1.  Create a submit file that runs `sw_probe.sh` 100 times and uses macros to write different `output`, `error`, and
     `log` files

--- a/docs/materials/osg/ex5-software-diffs.md
+++ b/docs/materials/osg/ex5-software-diffs.md
@@ -2,7 +2,7 @@
 status: testing
 ---
 
-dHTC Exercise 5: Software Differences in the OSG
+Grid Exercise 5: Software Differences in the OSG
 ================================================
 
 The goal of this exercise is to see the differences in availability of software in the OSG.
@@ -110,7 +110,7 @@ get_version 'nslookup'
 For this part of the exercise, try creating a submit file without referring to previous exercises!
 
 1.  Log in to `login04.osgconnect.net`
-1.  Create and change into a new folder for this exercise, e.g. `dhtc-ex5`
+1.  Create and change into a new folder for this exercise, e.g. `grid-ex5`
 1.  Save the above script as a file named `sw_probe.sh`
 1.  Create a submit file that runs `sw_probe.sh` 100 times and uses macros to write different `output`, `error`, and
     `log` files


### PR DESCRIPTION
I thought OSG is a little confusing here since ostensibly all sections are "OSG" since it's part of the OSG Virtual School. Alternatively I could just rename the section in the Overview page `Running in the OSG` and keep all the exercises named `OSG Exercise N`

Thoughts @lmichael107?