### PR TITLE
request_disk is required in CHTC

### DIFF
--- a/docs/materials/osg/ex4-hardware-diffs.md
+++ b/docs/materials/osg/ex4-hardware-diffs.md
@@ -45,6 +45,10 @@ following submit file:
 ```
 executable = /bin/sleep
 
+request_cpus = 1
+request_memory = 1MB
+request_disk = 1MB
+
 queue 2 arguments in (
 5
 10


### PR DESCRIPTION
Since we enforce request_disk in CHTC now, let's be annoying
(and encouraging of good habits) by requesting cpu, memory,
and disk for even small examples.